### PR TITLE
Custom Unit Synthesis Patcher

### DIFF
--- a/TrainworksModdingTools/Builders/CardBuilders/CardEffectDataBuilder.cs
+++ b/TrainworksModdingTools/Builders/CardBuilders/CardEffectDataBuilder.cs
@@ -30,16 +30,10 @@ namespace Trainworks.Builders
             set
             {
                 this.effectStateType = value;
-                // Bad way to do this, but just wanted to indicate somewhere that this specific string is checked for when resetting UnitSynthesisMapping through its CollectMappingData method
+                // I was unclear if the AssemblyName was critical here, so just wanted to point out a potential spot to specifically make sure CardEffectMonsterSpawn gave exactly the proper string even if modder did not specify.
+                // Quick testing showed no ill effects, but could understand if there were more working behind the scenes I missed.
                 // Modders can also just specifically set the EffectStateName AFTER setting the EffectStateType in their CardEffectDataBuilder, but wanted to find a way to protect them from themselves
-                if(this.effectStateType.GetType() == typeof(CardEffectSpawnMonster))
-                {
-                    this.EffectStateName = "CardEffectSpawnMonster";
-                }
-                else
-                {
-                    this.EffectStateName = this.effectStateType.AssemblyQualifiedName;
-                }
+                this.EffectStateName = this.effectStateType.Name;
             }
         }
 

--- a/TrainworksModdingTools/Builders/CardBuilders/CardEffectDataBuilder.cs
+++ b/TrainworksModdingTools/Builders/CardBuilders/CardEffectDataBuilder.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnityEngine.AddressableAssets;
 using ShinyShoe;
 using Trainworks.Managers;
+using System.Runtime.CompilerServices;
 
 namespace Trainworks.Builders
 {
@@ -29,7 +30,16 @@ namespace Trainworks.Builders
             set
             {
                 this.effectStateType = value;
-                this.EffectStateName = this.effectStateType.AssemblyQualifiedName;
+                // Bad way to do this, but just wanted to indicate somewhere that this specific string is checked for when resetting UnitSynthesisMapping through its CollectMappingData method
+                // Modders can also just specifically set the EffectStateName AFTER setting the EffectStateType in their CardEffectDataBuilder, but wanted to find a way to protect them from themselves
+                if(this.effectStateType.GetType() == typeof(CardEffectSpawnMonster))
+                {
+                    this.EffectStateName = "CardEffectSpawnMonster";
+                }
+                else
+                {
+                    this.EffectStateName = this.effectStateType.AssemblyQualifiedName;
+                }
             }
         }
 

--- a/TrainworksModdingTools/Builders/UpgradeBuilders/CardUpgradeDataBuilder.cs
+++ b/TrainworksModdingTools/Builders/UpgradeBuilders/CardUpgradeDataBuilder.cs
@@ -34,15 +34,15 @@ namespace Trainworks.Builders
                 this.upgradeTitle = value;
                 if (this.UpgradeTitleKey == null)
                 {
-                    this.UpgradeTitleKey = this.UpgradeTitleKey + "_CardUpgradeData_UpgradeTitleKey";
+                    this.UpgradeTitleKey = this.upgradeTitle + "_CardUpgradeData_UpgradeTitleKey";
                 }
                 if (this.UpgradeDescriptionKey == null)
                 {
-                    this.UpgradeDescriptionKey = this.UpgradeTitleKey + "_CardUpgradeData_UpgradeDescriptionKey";
+                    this.UpgradeDescriptionKey = this.upgradeTitle + "_CardUpgradeData_UpgradeDescriptionKey";
                 }
                 if (this.UpgradeNotificationKey == null)
                 {
-                    this.UpgradeNotificationKey = this.UpgradeTitleKey + "_CardUpgradeData_UpgradeNotificationKey";
+                    this.UpgradeNotificationKey = this.upgradeTitle + "_CardUpgradeData_UpgradeNotificationKey";
                 }
             }
         }

--- a/TrainworksModdingTools/Patches/ResetUnitSynthesisMapping.cs
+++ b/TrainworksModdingTools/Patches/ResetUnitSynthesisMapping.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Trainworks.Patches
 {
-    class AccessUnitSynthesisMapping
+    public class AccessUnitSynthesisMapping
     {
         public static void FindUnitSynthesisMappingInstanceToStub()
         {
@@ -37,7 +37,7 @@ namespace Trainworks.Patches
     // Effective for creating unit synthesis connections in TLD DLC after appropriate custom CharacterData and custom CardUpgradeData has been added to AllGameData
     // *Required: Called after adding custom content to work for this purpose
     [HarmonyPatch(typeof(UnitSynthesisMapping), "CollectMappingData", new Type[] { })]
-    public class RecallingCollectMappingData
+    class RecallingCollectMappingData
     {
         [HarmonyReversePatch]
         public static void CollectMappingDataStub(object instance)

--- a/TrainworksModdingTools/Patches/ResetUnitSynthesisMapping.cs
+++ b/TrainworksModdingTools/Patches/ResetUnitSynthesisMapping.cs
@@ -1,0 +1,48 @@
+﻿using HarmonyLib;
+using Trainworks.Managers;
+using System;
+
+namespace Trainworks.Patches
+{
+    class AccessUnitSynthesisMapping
+    {
+        public static void FindUnitSynthesisMappingInstanceToStub()
+        {
+            // Gets a reference to AllGameData with Trainworks
+            AllGameData testData = ProviderManager.SaveManager.GetAllGameData();
+
+            // Use AllGameData to get access to BalanceData
+            BalanceData balanceData = testData.GetBalanceData();
+
+            // Use BalanceData to get access to the current instance of the UnitSynthesisMapping
+            UnitSynthesisMapping mappingInstance = balanceData.SynthesisMapping;
+            if (mappingInstance == null)
+            {
+                Trainworks.Log("Failed to find a mapping instance.");
+            }
+            else
+            {
+                Trainworks.Log("Able to find mapping instance: " + mappingInstance.GetID()); // Test to see if this is a different instance
+            }
+
+            // Calls CollectMappingData method
+            RecallingCollectMappingData.CollectMappingDataStub(mappingInstance);
+            Trainworks.Log("Called CollectMappingData.");
+        }
+    }
+
+
+    // Solely exists to allow calling of private method CollectMappingData from within a UnitSynthesisMapping instance
+    // This resets the editorMappings list within the UnitSynthesisMapping class in Monster Train
+    // Effective for creating unit synthesis connections in TLD DLC after appropriate custom CharacterData and custom CardUpgradeData has been added to AllGameData
+    // *Required: Called after adding custom content to work for this purpose
+    [HarmonyPatch(typeof(UnitSynthesisMapping), "CollectMappingData", new Type[] { })]
+    public class RecallingCollectMappingData
+    {
+        [HarmonyReversePatch]
+        public static void CollectMappingDataStub(object instance)
+        {
+            // It's a stub so it has no initial content
+        }
+    }
+}

--- a/TrainworksModdingTools/Patches/ResetUnitSynthesisMapping.cs
+++ b/TrainworksModdingTools/Patches/ResetUnitSynthesisMapping.cs
@@ -18,7 +18,7 @@ namespace Trainworks.Patches
             UnitSynthesisMapping mappingInstance = balanceData.SynthesisMapping;
             if (mappingInstance == null)
             {
-                Trainworks.Log("Failed to find a mapping instance.");
+                Trainworks.Log(BepInEx.Logging.LogLevel.Warning, "Failed to find a mapping instance.");
             }
             else
             {
@@ -27,15 +27,17 @@ namespace Trainworks.Patches
 
             // Calls CollectMappingData method
             RecallingCollectMappingData.CollectMappingDataStub(mappingInstance);
-            Trainworks.Log("Called CollectMappingData.");
         }
     }
 
-
-    // Solely exists to allow calling of private method CollectMappingData from within a UnitSynthesisMapping instance
-    // This resets the editorMappings list within the UnitSynthesisMapping class in Monster Train
-    // Effective for creating unit synthesis connections in TLD DLC after appropriate custom CharacterData and custom CardUpgradeData has been added to AllGameData
-    // *Required: Called after adding custom content to work for this purpose
+    /// <summary>
+    /// Solely exists to allow calling of private method CollectMappingData from within a UnitSynthesisMapping instance
+    /// This resets the editorMappings list within the UnitSynthesisMapping class in Monster Train
+    /// Effective for creating unit synthesis connections in TLD DLC after appropriate custom CharacterData and custom CardUpgradeData has been added to AllGameData
+    /// *Required: Called after adding custom content to work for this purpose
+    /// Current Use: Each mod will have access to this Trainworks method so they can call it after adding all their content (At the end of their Initialize method generally works)
+    /// Ideally: This is called a single time after all mods/plugins have added their custom content
+    /// </summary>
     [HarmonyPatch(typeof(UnitSynthesisMapping), "CollectMappingData", new Type[] { })]
     class RecallingCollectMappingData
     {


### PR DESCRIPTION
This is a starting foundation for a process that helps modders create unit syntheses for their custom units in Monster Train's The Last Divinity DLC. 

**ResetUnitSynthesisMapping**:
The ResetUnitSynthesisMapping contains the entirety of this main feature. It accesses Monster Train's existing instance of a new post-DLC class named UnitSynthesisMapping and calls its CollectMappingData from within. This resets the editorMapping list (responsible for knowing the connections between CharacterData and CardUpgradeData that make up a synthesis pair) searches through AllGameData finding all the CharacterData (including newly added custom ones), and then tries to pair them up with CardUpgradeData (including newly added custom ones), again found in AllGameData. Ideally this is called once after ALL mods have added their custom content, but even calling it multiple times (such as after each mod is initialized) should theoretically be ok, just not efficient.

**Other Edits**:
The suggested changes I made to CardEffectDataBuilder and CardUpgradeDataBuilder are just there to make it more apparent what this process needs to occur properly, and what default values will cause issues if the modder does not set them properly.

CardEffectDataBuilder edit:
CollectMappingData uses a specific string check looking for a CardEffect named "CardEffectSpawnMonster" to identify that a card is indeed a monster character, so the Trainworks default value from AssemblyQualifiedName will NOT satisfy this. Modders can get around this by just making sure to set that specific EffectStateName AFTER setting the EffectStateType, but wanted to point that out and make a suggestion just to see if there is a clean solution to that (I am unclear how necessary AssemblyQualifiedName is there).

CardUpgradeDataBuilder edit:
The CardUpgradeDataBuilder edit was suggested because it appears Trainworks removes CardUpgradeData objects in the overall AllGameData list if it finds multiple have the same UpgradeTitleKey (as a solid duplication check), however, if that was not set for several upgrades (unit synthesis upgrades in this case), they would all receive the same exact UpgardeTitleKey (because they all have NULL, and the original setup would just add NULL before a fixed string, naming them the same). My suggestion is to just use the upgradeTitle there instead to make sure they are unique even if the modder doesn't set them to something else.